### PR TITLE
Two unit test failures

### DIFF
--- a/src/deda/plugins/perforce/__init__.py
+++ b/src/deda/plugins/perforce/__init__.py
@@ -19,11 +19,9 @@
 The builtin Asset Manager plugin connects to perforce and uses p4python to handle file operations. 
 
 """
-import os
 import logging
 from contextlib import contextmanager
 from pathlib import Path
-import P4
 
 import deda.core
 
@@ -39,6 +37,13 @@ def P4Connection():
     """The p4 plugin uses env variables to connect to Perforce. 
 
     """
+    try:
+        import P4
+    except ModuleNotFoundError as err:
+        raise ModuleNotFoundError(
+            'The p4python package is required to use the Perforce plugin.'
+        ) from err
+
     p4c = P4.P4()
     try:
         p4c.connect()


### PR DESCRIPTION
Defer `P4` import in `deda.plugins.perforce` to fix unit test failures when `p4python` is not installed.

The `tests/test_imports.py` suite failed because `deda.plugins.perforce` attempted a top-level import of `P4`, which caused an `ImportError` if the `p4python` bindings were not present in the environment. This change ensures the module can be imported successfully without `P4` being immediately available.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-864d3f35-7a90-46b6-ad6f-db6ab11432c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-864d3f35-7a90-46b6-ad6f-db6ab11432c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

